### PR TITLE
fix(ci): grant contents:write so coverage publish can push gh-pages

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -5,7 +5,7 @@ on:
     branches: [develop]
 
 permissions:
-  contents: read
+  contents: write
 
 jobs:
   ci:


### PR DESCRIPTION
## Summary
CI failed on the direct push that wired ci.yaml to the new shared go-ci.yaml workflow (that push should have gone through a PR - my mistake, see conversation). The coverage-publish step needs `contents: write` to push `gh-pages`; a caller's `permissions:` block caps what a called reusable workflow can do, so both this wrapper and `go-ci.yaml` itself needed the bump.

## Test plan
- [x] CI run on this PR should show the coverage-publish step succeeding