### PR TITLE
chore(release): merge master into develop after v0.0.16

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 All notable changes to this project will be documented in this file.
 
+## 0.0.16 - 2026-07-22
+
+### Documentation
+- Update AGENTS.md Releases section for the new release workflow
+- Update README (#10)
+
+### Fixed
+- Drop unmaintained golint from PR workflow
+
 ## [Unreleased]
 
 ### Added


### PR DESCRIPTION
Manual merge-back after the automated release workflow's merge-back step hit a CHANGELOG.md add/add conflict (release notes prepended above the H1 header vs. develop's Unreleased section). Resolved by reordering: released version section, then Unreleased.